### PR TITLE
🧹 Freeze Fluentassertions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,9 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":approveMajorUpdates"
   ],
   "assignees": [ "candoumbe" ],
   "addLabels": [ "renovate", "package-update" ],
-  "automerge": true
+  "automergeStrategy": "rebase"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,12 @@
 {
   "extends": [
     "config:base",
-    ":approveMajorUpdates"
+    ":approveMajorUpdates",
+    ":assignee(candoumbe)",
+    ":reviewer(candoumbe)",
+    ":automergePatch",
+    "automergeStableNonMajor"
   ],
-  "assignees": [ "candoumbe" ],
   "addLabels": [ "renovate", "package-update" ],
   "automergeStrategy": "rebase"
 }

--- a/tests/Forms.UnitTests/Candoumbe.Forms.UnitTests.csproj
+++ b/tests/Forms.UnitTests/Candoumbe.Forms.UnitTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="35.6.1" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.0.0]" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.*" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.categories" Version="2.0.8" />

--- a/tests/Forms.UnitTests/Candoumbe.Forms.UnitTests.csproj
+++ b/tests/Forms.UnitTests/Candoumbe.Forms.UnitTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="35.6.1" />
-    <PackageReference Include="FluentAssertions" Version="8.0.0" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.*" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.categories" Version="2.0.8" />


### PR DESCRIPTION
### 🚀 New features
• Added net8.0 TFM support
• Added support of DateOnly properties
### ⚠️ Breaking changes
• Changed Link.Relation from string to string[] [BREAKING]
• Dropped netstandard1.0 TFM support
• Dropped net5.0 TFM support
• Removed Ultimately dependency
• Changed IonResourceto a record (netstandard2.1• and net5+)
• Changed Formto a record (netstandard2.1• and net5+)
• Changed FormFieldto a record (netstandard2.1• and net5+)
• Changed Linkto a record (netstandard2.1• and net5+)
### 🧹 Housekeeping
• Updated Candoumbe.Pipelines to 0.12.1
• Updated Candoumbe.MiscUtilities to 0.14.0
• Improve unit tests readability

Full changelog at https://github.com/candoumbe/Forms/blob/coldfix/freeze-fluentassertions/CHANGELOG.md

Resolves #162